### PR TITLE
#2: Add Gatestone 2

### DIFF
--- a/plugin/models.lua
+++ b/plugin/models.lua
@@ -151,6 +151,15 @@ local gatestones = {
 			b = { 102, 105 },
 		},
 	},
+	gatestone2 = {
+		vertcount = 585,
+		zerothvertpos = { 40, 76, 36 },
+		zerothvertcolourrange = {
+			r = { 104, 104 },
+			g = { 36, 36 },
+			b = { 32, 32 },
+		},
+	},
 }
 
 return {


### PR DESCRIPTION
It was the same colour for all floor types. I'm suspecting that there is something else going on, not just the floors affecting the colour but maybe also graphical settings?